### PR TITLE
failures, and new RnD mechanic

### DIFF
--- a/Failure Modules/TestFlightFailure_AvionicsThrustJam.cs
+++ b/Failure Modules/TestFlightFailure_AvionicsThrustJam.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using TestFlightAPI;
+
+namespace TestFlight.Failure_Modules
+{
+    public class TestFlightFailure_AvionicsThrustJam : TestFlightFailureBase
+    {
+        [KSPField(isPersistant = true)]
+        public float throttle;
+
+        public override void DoFailure()
+        {
+            base.DoFailure();
+            if (base.vessel != null && base.part != null && base.vessel.referenceTransformId == base.part.flightID)
+            {
+                base.vessel.OnFlyByWire -= this.OnFlyByWire;
+                base.vessel.OnFlyByWire += this.OnFlyByWire;
+                this.throttle = base.vessel.ctrlState.mainThrottle;
+            }
+        }
+        public override float DoRepair()
+        {
+            base.DoRepair();
+            if (base.vessel != null)
+            {
+                base.vessel.OnFlyByWire -= this.OnFlyByWire;
+            }
+            return 0f;
+        }
+        public override void OnFlyByWire(FlightCtrlState s)
+        {
+            s.mainThrottle = this.throttle;
+        }
+        public void OnDestroy()
+        {
+            if (base.vessel != null)
+            {
+                base.vessel.OnFlyByWire -= this.OnFlyByWire;
+            }
+        }
+    }
+}

--- a/Failure Modules/TestFlightFailure_SolarTracking.cs
+++ b/Failure Modules/TestFlightFailure_SolarTracking.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using KSP;
+
+namespace TestFlight.Failure_Modules
+{
+    public class TestFlightFailure_SolarTracking : TestFlightFailureBase_Solar
+    {
+        public override void DoFailure()
+        {
+            base.DoFailure();
+            base.module.trackingSpeed = 0;
+        }
+        public override float DoRepair()
+        {
+            base.DoRepair();
+            if (base.part != null && base.part.partInfo != null)
+            {
+                Part pf = base.part.partInfo.partPrefab;
+                if (pf != null)
+                {
+                    ModuleDeployableSolarPanel pm = (ModuleDeployableSolarPanel)pf.Modules.OfType<ModuleDeployableSolarPanel>();
+                    if (pm != null)
+                    {
+                        base.module.trackingSpeed = pm.trackingSpeed;
+                    }
+                }
+            }
+            return 0f;
+        }
+    }
+}

--- a/Failure Modules/TestFlightFailure_SolarTracking.cs
+++ b/Failure Modules/TestFlightFailure_SolarTracking.cs
@@ -9,26 +9,17 @@ namespace TestFlight.Failure_Modules
 {
     public class TestFlightFailure_SolarTracking : TestFlightFailureBase_Solar
     {
+        private float trackingSpeed = 0f;
         public override void DoFailure()
         {
             base.DoFailure();
+            this.trackingSpeed = base.module.trackingSpeed;
             base.module.trackingSpeed = 0;
         }
         public override float DoRepair()
         {
             base.DoRepair();
-            if (base.part != null && base.part.partInfo != null)
-            {
-                Part pf = base.part.partInfo.partPrefab;
-                if (pf != null)
-                {
-                    ModuleDeployableSolarPanel pm = (ModuleDeployableSolarPanel)pf.Modules.OfType<ModuleDeployableSolarPanel>();
-                    if (pm != null)
-                    {
-                        base.module.trackingSpeed = pm.trackingSpeed;
-                    }
-                }
-            }
+            base.module.trackingSpeed = this.trackingSpeed;
             return 0f;
         }
     }

--- a/TestFlight.csproj
+++ b/TestFlight.csproj
@@ -75,6 +75,7 @@
     <Compile Include="Failure Modules\TestFlightFailure_AvionicsGlitch.cs" />
     <Compile Include="Failure Modules\TestFlightFailure_AvionicsInvert.cs" />
     <Compile Include="Failure Modules\TestFlightFailure_AvionicsPartial.cs" />
+    <Compile Include="Failure Modules\TestFlightFailure_AvionicsThrustJam.cs" />
     <Compile Include="Failure Modules\TestFlightFailure_AvionicsTotal.cs" />
     <Compile Include="Failure Modules\TestFlightFailure_DockingClamp.cs" />
     <Compile Include="Failure Modules\TestFlightFailure_DockingFeed.cs" />
@@ -88,6 +89,7 @@
     <Compile Include="Failure Modules\TestFlightFailure_ReactionTorque.cs" />
     <Compile Include="Failure Modules\TestFlightFailure_ResourcePump.cs" />
     <Compile Include="Failure Modules\TestFlightFailure_SolarMech.cs" />
+    <Compile Include="Failure Modules\TestFlightFailure_SolarTracking.cs" />
     <Compile Include="Failure Modules\TestFlightFailure_WheelBrake.cs" />
     <Compile Include="Failure Modules\TestFlightFailure_WheelMotor.cs" />
     <Compile Include="Failure Modules\TestFlightFailure_WheelSteer.cs" />

--- a/TestFlightCore/TestFlightCore/TestFlightCore.cs
+++ b/TestFlightCore/TestFlightCore/TestFlightCore.cs
@@ -46,6 +46,8 @@ namespace TestFlightCore
         public float maxData = 0f;
         [KSPField(isPersistant=true)]
         public float failureRateModifier = 1f;
+        [KSPField]
+        public int scienceDataValue = 0;
 
         private double baseFailureRate;
         // We store the base, or initial, flight data for calculation of Base Failure Rate

--- a/TestFlightCore/TestFlightCore/TestFlightCore.csproj
+++ b/TestFlightCore/TestFlightCore/TestFlightCore.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestFlight.cs" />
     <Compile Include="TestFlightCore.cs" />
+    <Compile Include="TestFlightRnD.cs" />
     <Compile Include="UserInterface.cs" />
     <Compile Include="Framework\ConfigNodeStorage.cs" />
     <Compile Include="Framework\ExtensionsUnity.cs" />
@@ -94,8 +95,5 @@
       <Name>TestFlightAPI</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Framework\" />
-    <Folder Include="FrameworkExt\" />
-  </ItemGroup>
+  <ItemGroup />
 </Project>

--- a/TestFlightCore/TestFlightCore/TestFlightCore.csproj
+++ b/TestFlightCore/TestFlightCore/TestFlightCore.csproj
@@ -95,5 +95,9 @@
       <Name>TestFlightAPI</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Framework\" />
+    <Folder Include="FrameworkExt\" />
+  </ItemGroup>
   <ItemGroup />
 </Project>

--- a/TestFlightCore/TestFlightCore/TestFlightRnD.cs
+++ b/TestFlightCore/TestFlightCore/TestFlightRnD.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using UnityEngine;
+using TestFlightAPI;
+
+namespace TestFlightCore
+{
+    [KSPAddon(KSPAddon.Startup.SpaceCentre, true)]
+    public class TestFlightRnD : MonoBehaviour
+    {
+        Dictionary<string, int> baseCost = null;
+        public void Start()
+        {
+            RDController.OnRDTreeSpawn.Add(new EventData<RDController>.OnEvent(OnTreeSpawn));
+            DontDestroyOnLoad(this);
+        }
+        public void OnTreeSpawn(RDController controller)
+        {
+            if (TestFlightManagerScenario.Instance == null || controller.nodes == null)
+            {
+                return;
+            }
+            List<RDNode> nodes = controller.nodes;
+            if (this.baseCost == null)
+            {
+                baseCost = new Dictionary<string, int>();
+                for (int i = 0; i < nodes.Count; i++)
+                {
+                    RDNode node = nodes[i];
+                    if (node != null && node.tech != null)
+                    {
+                        baseCost.Add(nodes[i].tech.techID, nodes[i].tech.scienceCost);
+                    }
+                }
+            }
+            for (int n = 0; n < nodes.Count; n++)
+            {
+                RDNode node = nodes[n];
+                if (node != null && node.tech != null && !node.IsResearched && node.tech.partsAssigned != null)
+                {
+                    float discount = 0f;
+                    List<AvailablePart> parts = node.tech.partsAssigned;
+                    for (int p = 0; p < parts.Count; p++)
+                    {
+                        if (parts[p] != null)
+                        {
+                            Part prefab = parts[p].partPrefab;
+                            TestFlightPartData partData = TestFlightManagerScenario.Instance.GetPartDataForPart(parts[p].name);
+                            if (partData != null && prefab != null)
+                            {
+                                TestFlightCore core = (TestFlightCore)prefab.Modules.OfType<TestFlightCore>().FirstOrDefault();
+                                float flightData = partData.GetFloat("flightData");
+                                if (core != null && flightData > core.startFlightData)
+                                {
+                                    discount += (int)(((flightData - core.startFlightData) / (core.maxData - core.startFlightData)) * core.scienceDataValue);
+                                }
+                            }
+                        }
+                    }
+                    if (discount > 0)
+                    {
+                        node.tech.scienceCost = (int)Math.Max(0, baseCost[node.tech.techID] - discount);
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Failures:
-AvionicsThrustJam
-SolarTracking
New mechanic: Hands on RnD
-Flight data gained from parts lowers the science cost of tech tree nodes. currently this only applies to the node the part is assigned to, which means ModuleTestSubject is needed to provide "sneak peek" access to a part, to gather said data, raising the value of part testing contracts. 