### PR TITLE
Make generation counter specific to branch loop

### DIFF
--- a/TestFlightCore/TestFlightCore/TestFlightCore.cs
+++ b/TestFlightCore/TestFlightCore/TestFlightCore.cs
@@ -948,7 +948,6 @@ namespace TestFlightCore
             float dataToTransfer = 0f;
             string[] branches;
             string[] modifiers;
-            int generation = 0;
 
             branches = techTransfer.Split(new char[1]{ '&' });
 
@@ -960,6 +959,7 @@ namespace TestFlightCore
                 string[] partsInBranch = modifiers[0].Split(new char[1]{ ',' });
                 float branchModifier = float.Parse(modifiers[1]);
                 branchModifier /= 100f;
+                int generation = 0;
                 foreach (string partName in partsInBranch)
                 {
                     float partFlightData = TestFlightManagerScenario.Instance.GetFlightDataForPartName(partName);


### PR DESCRIPTION
The comment on line 1061 implies that each branch should have its own generation counter. However, in the previous code the counter was only initialized once before all the branches were processed.