### PR TITLE
Prevent failed engines from re-activating.

### DIFF
--- a/TestFlightFailure_IgnitionFail.cs
+++ b/TestFlightFailure_IgnitionFail.cs
@@ -133,6 +133,11 @@ namespace TestFlight
                 if (engine.failEngine)
                 {
                     engine.engine.Shutdown();
+                    // For some reason, need to disable GUI as well
+                    engine.engine.Events["Activate"].active = false;
+                    engine.engine.Events["Shutdown"].active = false;
+                    engine.engine.Events["Activate"].guiActive = false;
+                    engine.engine.Events["Shutdown"].guiActive = false;
                     if ((restoreIgnitionCharge) || (this.vessel.situation == Vessel.Situations.PRELAUNCH) )
                         RestoreIgnitor();
                     engines[i].failEngine = false;
@@ -148,6 +153,9 @@ namespace TestFlight
                 EngineHandler engine = engines[i];
                 {
                     engine.engine.Shutdown();
+                    engine.engine.Events["Activate"].active = true;
+                    engine.engine.Events["Activate"].guiActive = true;
+                    engine.engine.Events["Shutdown"].guiActive = true;
                     if (restoreIgnitionCharge || this.vessel.situation == Vessel.Situations.PRELAUNCH)
                         RestoreIgnitor();
                     engines[i].failEngine = false;

--- a/TestFlightFailure_ShutdownEngine.cs
+++ b/TestFlightFailure_ShutdownEngine.cs
@@ -38,6 +38,11 @@ namespace TestFlight
                 engineState.allowShutdown = engine.engine.allowShutdown;
                 engineState.numIgnitions = engine.engine.GetIgnitionCount();
                 engine.engine.Shutdown();
+                // For some reason, need to disable GUI as well
+                engine.engine.Events["Activate"].active = false;
+                engine.engine.Events["Shutdown"].active = false;
+                engine.engine.Events["Activate"].guiActive = false;
+                engine.engine.Events["Shutdown"].guiActive = false;
                 engineStates.Add(id, engineState);
                 engine.engine.RemoveIgnitions(-1);
             }
@@ -53,6 +58,9 @@ namespace TestFlight
                 if (engineStates.ContainsKey(id))
                 {
                     engine.engine.enabled = true;
+                    engine.engine.Events["Activate"].active = true;
+                    engine.engine.Events["Activate"].guiActive = true;
+                    engine.engine.Events["Shutdown"].guiActive = true;
                     engine.engine.allowShutdown = engineStates[id].allowShutdown;
                     engine.engine.SetIgnitionCount(engineStates[id].numIgnitions);
                 }


### PR DESCRIPTION
This commit suppresses the Activate/Deactivate Engine right-click command when an engine experiences a shutdown failure, and restores the GUI when the engine is repaired. I don't understand why `ModuleEngines` requires me to set the events' `guiActive` when other modules make do with just `active`. Fixes #160.

I have only tested this fix on stock KSP, not RO.