### PR TITLE
Re-enable ignition failures

### DIFF
--- a/TestFlightFailure_Engine.cs
+++ b/TestFlightFailure_Engine.cs
@@ -27,13 +27,19 @@ namespace TestFlight
         {
             get
             {
+                ITestFlightCore core = TestFlightUtil.GetCore (this.part, Configuration);
+                if (core == null)
+                {
+                    Log ("EngineBase: No TestFlight core found");
+                    return false;
+                }
                 // Make sure we have valid engines
                 if (engines == null)
                 {
                     Log("EngineBase: No valid engines found");
                     return false;
                 }
-                return TestFlightUtil.EvaluateQuery(Configuration, this.part);
+                return core.TestFlightEnabled;
             }
         }
 

--- a/TestFlightFailure_IgnitionFail.cs
+++ b/TestFlightFailure_IgnitionFail.cs
@@ -31,20 +31,6 @@ namespace TestFlight
 
         private ITestFlightCore core = null;
 
-        public new bool TestFlightEnabled
-        {
-            get
-            {
-                // verify we have a valid core attached
-                if (core == null)
-                    return false;
-                // and a valid engine
-                if (engines == null)
-                    return false;
-                return TestFlightUtil.EvaluateQuery(Configuration, this.part);
-            }
-        }
-
         public override void OnStart(StartState state)
         {
             base.OnStart(state);

--- a/TestFlightFailure_IgnitionFail.cs
+++ b/TestFlightFailure_IgnitionFail.cs
@@ -133,6 +133,7 @@ namespace TestFlight
             {
                 EngineHandler engine = engines[i];
                 {
+                    // Prevent auto-ignition on repair
                     engine.engine.Shutdown();
                     if (restoreIgnitionCharge || this.vessel.situation == Vessel.Situations.PRELAUNCH)
                         RestoreIgnitor();


### PR DESCRIPTION
`TestFlightFailure_IgnitionFail` will now be checked when engines ignite. The new code works with both manual and default values of the `configuration` fields. Fixes #163.

I also added a comment clarifying that repairing an ignition failure really should shut down the engine, as the code looks counterintuitive.