### PR TITLE
Exclude ignore.txt files from release ZIPs

### DIFF
--- a/makefile
+++ b/makefile
@@ -39,7 +39,7 @@ endif
 
 configs: $(CONFIG_DIR)/Stock/%.cfg
 	cp $(CONFIG_DIR)/Stock/*.cfg GameData/TestFlight/Config
-	zip $(ZIP_STOCK) GameData/TestFlight/Config/*
+	zip $(ZIP_STOCK) GameData/TestFlight/Config/* -x ignore.txt
 
 $(CONFIG_DIR)/Stock/%.cfg:
 	cd $(CONFIG_DIR);python compileYamlConfigs.py Stock
@@ -54,7 +54,7 @@ meta:
 endif
 
 zip: meta configs
-	zip $(ZIP_CORE) GameData GameData/TestFlight/* GameData/TestFlight/Plugins/* GameData/TestFlight/Resources/* GameData/TestFlight/Resources/Textures/*
+	zip $(ZIP_CORE) GameData GameData/TestFlight/* GameData/TestFlight/Plugins/* GameData/TestFlight/Resources/* GameData/TestFlight/Resources/Textures/* -x ignore.txt
 
 clean:
 	-rm $(CONFIG_DIR)/Stock/*.cfg


### PR DESCRIPTION
This mod currently ships two ZIP files that both try to install `GameData\TestFlight\Config\ignore.txt`, a zero byte file that isn't needed for the mod to function. I believe it was created so the Config folder would exist when the repo is cloned, because git does not support committing empty directories.

Luckily, the makefile generates the ZIPs with the `zip` command, which allows an `-x` argument to exclude files matching a pattern.

Now the build process is updated to exclude these files from the generated ZIP files.

Fixes #191.