### PR TITLE
Fix problem with excluding ignore.txt

### DIFF
--- a/makefile
+++ b/makefile
@@ -39,7 +39,7 @@ endif
 
 configs: $(CONFIG_DIR)/Stock/%.cfg
 	cp $(CONFIG_DIR)/Stock/*.cfg GameData/TestFlight/Config
-	zip $(ZIP_STOCK) GameData/TestFlight/Config/* -x ignore.txt
+	zip $(ZIP_STOCK) -r GameData/TestFlight/Config -x ignore.txt
 
 $(CONFIG_DIR)/Stock/%.cfg:
 	cd $(CONFIG_DIR);python compileYamlConfigs.py Stock


### PR DESCRIPTION
## Problem

After #192, `ignore.txt` was removed from the core ZIP but not the config ZIP:

https://travis-ci.org/KSP-RO/TestFlight/builds/556073738#L248-L277

```
cp configs/Stock/*.cfg GameData/TestFlight/Config
zip TestFlightConfigStock-dev_634.zip GameData/TestFlight/Config/* -x ignore.txt
  adding: GameData/TestFlight/Config/ignore.txt (stored 0%)
  adding: GameData/TestFlight/Config/Squad_Tanks.cfg (deflated 53%)
  adding: GameData/TestFlight/Config/Stock_Engines.cfg (deflated 93%)
zip TestFlightCore-dev_634.zip GameData GameData/TestFlight/* GameData/TestFlight/Plugins/* GameData/TestFlight/Resources/* GameData/TestFlight/Resources/Textures/* -x ignore.txt
  adding: GameData/ (stored 0%)
  adding: GameData/TestFlight/Config/ (stored 0%)
  adding: GameData/TestFlight/Plugins/ (stored 0%)
  adding: GameData/TestFlight/Properties/ (stored 0%)
  adding: GameData/TestFlight/Resources/ (stored 0%)
  adding: GameData/TestFlight/Plugins/TestFlightAPI.dll (deflated 58%)
  adding: GameData/TestFlight/Plugins/TestFlightContracts.dll (deflated 58%)
  adding: GameData/TestFlight/Plugins/TestFlightContracts.dll.mdb (deflated 39%)
  adding: GameData/TestFlight/Plugins/TestFlightCore.dll (deflated 59%)
  adding: GameData/TestFlight/Plugins/TestFlight.dll (deflated 58%)
  adding: GameData/TestFlight/Resources/AppLauncherIcon.png (deflated 70%)
  adding: GameData/TestFlight/Resources/ChevronDown.png (deflated 74%)
  adding: GameData/TestFlight/Resources/ChevronLeft.png (deflated 74%)
  adding: GameData/TestFlight/Resources/ChevronRight.png (deflated 74%)
  adding: GameData/TestFlight/Resources/ChevronUp.png (deflated 74%)
  adding: GameData/TestFlight/Resources/Textures/ (stored 0%)
  adding: GameData/TestFlight/Resources/Textures/img_PanelBack.png (stored 0%)
  adding: GameData/TestFlight/Resources/Textures/img_PanelBack_Trans.png (deflated 6%)
  adding: GameData/TestFlight/Resources/Textures/img_PanelSolarizedDark.png (deflated 74%)
  adding: GameData/TestFlight/Resources/Textures/img_PartWindowHead.png (deflated 6%)
  adding: GameData/TestFlight/Resources/Textures/img_SeparatorHorizontal.png (deflated 3%)
  adding: GameData/TestFlight/Resources/Textures/img_SeparatorVertical.png (deflated 3%)
  adding: GameData/TestFlight/Resources/Textures/tex_Box.png (deflated 5%)
```

## Cause

I think this is because the `GameData/TestFlight/Config/*` glob directly matched the file name added it to the command line, and `-x` only applies to the process of finding files that are referenced indirectly, via directory names.

https://github.com/KSP-RO/TestFlight/blob/f6bd8d718d55ad841bca04b65e1c9c7e2785831c/makefile#L42

## Changes

Now the `Config` directory is zipped instead of its contents, so the exclude can do its work.