### PR TITLE
Performance Tweaks and Refactoring

### DIFF
--- a/FlightDataRecorder.cs
+++ b/FlightDataRecorder.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using UnityEngine;
-using TestFlightAPI;
+﻿using TestFlightAPI;
 
 namespace TestFlight
 {
@@ -10,10 +7,6 @@ namespace TestFlight
 
     public class FlightDataRecorder : FlightDataRecorderBase
     {
-        public override void OnAwake()
-        {
-            base.OnAwake();
-        }
     }
 }
 

--- a/FlightDataRecorder_Engine.cs
+++ b/FlightDataRecorder_Engine.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using UnityEngine;
-
-using TestFlightAPI;
+﻿using TestFlightAPI;
 
 namespace TestFlight
 {
@@ -10,31 +6,16 @@ namespace TestFlight
     {
         private EngineModuleWrapper engine;
 
-        public override void OnAwake()
-        {
-            base.OnAwake();
-        }
-
         public override void OnStart(StartState state)
         {
             base.OnStart(state);
             engine = new EngineModuleWrapper();
             engine.Init(this.part);
         }
+
         public override bool IsPartOperating()
         {
-            if (!isEnabled)
-                return false;
-
-            return engine.IgnitionState == EngineModuleWrapper.EngineIgnitionState.IGNITED;
-        }
-
-        public override bool IsRecordingFlightData()
-        {
-            if (this.part.vessel.situation == Vessel.Situations.PRELAUNCH)
-                return false;
-
-            return IsPartOperating();
+            return base.IsPartOperating() && engine.IgnitionState == EngineModuleWrapper.EngineIgnitionState.IGNITED;
         }
     }
 }

--- a/FlightDataRecorder_Resources.cs
+++ b/FlightDataRecorder_Resources.cs
@@ -1,44 +1,24 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using UnityEngine;
-
-using TestFlightAPI;
+﻿using TestFlightAPI;
 
 namespace TestFlight
 {
-
-    // Method for determing distance from kerbal to part
-    // float kerbalDistanceToPart = Vector3.Distance(kerbal.transform.position, targetPart.collider.ClosestPointOnBounds(kerbal.transform.position));
     public class FlightDataRecorder_Resources : FlightDataRecorderBase
     {
         [KSPField]
         public double emptyThreshold = 0.1;
 
-        public override void OnAwake()
-        {
-            base.OnAwake();
-        }
-
         public override bool IsRecordingFlightData()
         {
-            bool isRecording = false;
-
-            if (!isEnabled)
-                return false;
-
-            if (this.part.vessel.situation == Vessel.Situations.PRELAUNCH)
-                return false;
-
-            List<PartResource> partResources = this.part.Resources.ToList();
-            foreach (PartResource resource in partResources)
+            // base checks: TF enabled, PartModule isEnabled, IsPartOperating() and Vessel.situation
+            if (base.IsRecordingFlightData())
             {
-                if (resource.amount > emptyThreshold)
-                    return true;
+                foreach (PartResource resource in this.part.Resources)
+                {
+                    if (resource.amount > emptyThreshold)
+                        return true;
+                }
             }
-
-            return isRecording;
+            return false;
         }
     }
 }

--- a/TestFlightAPI/TestFlightAPI/TestFlightFailure.cs
+++ b/TestFlightAPI/TestFlightAPI/TestFlightFailure.cs
@@ -161,10 +161,7 @@ namespace TestFlightAPI
             currentConfig.TryGetValue("oneShot", ref oneShot);
         }
 
-        public virtual List<string> GetTestFlightInfo()
-        {
-            return null;
-        }
+        public virtual List<string> GetTestFlightInfo() => new List<string>();
 
         public override void OnAwake()
         {

--- a/TestFlightAPI/TestFlightAPI/TestFlightFailure.cs
+++ b/TestFlightAPI/TestFlightAPI/TestFlightFailure.cs
@@ -71,7 +71,7 @@ namespace TestFlightAPI
         }
 
         /// <summary>
-        /// Gets the details of the failure encapsulated by this module.  In most cases you can let the base class take care of this unless oyu need to do somethign special
+        /// Gets the details of the failure encapsulated by this module.  In most cases you can let the base class take care of this unless you need to do something special
         /// </summary>
         /// <returns>The failure details.</returns>
         public virtual TestFlightFailureDetails GetFailureDetails()

--- a/TestFlightCore/TestFlightCore/TestFlight.cs
+++ b/TestFlightCore/TestFlightCore/TestFlight.cs
@@ -401,8 +401,11 @@ namespace TestFlightCore
         // New noscope
         public Dictionary<string, TestFlightPartData> partData = null;
 
-        [KSPField(isPersistant = true)] public bool SettingsEnabled = true;
-        [KSPField(isPersistant = true)] public bool SettingsAlwaysMaxData = false;
+        [KSPField(isPersistant = true)] public bool settingsEnabled = true;
+        [KSPField(isPersistant = true)] public bool settingsAlwaysMaxData = false;
+        public bool SettingsEnabled { get { return settingsEnabled; } set { settingsEnabled = value; } }
+        public bool SettingsAlwaysMaxData { get { return settingsAlwaysMaxData; } set { settingsAlwaysMaxData = value; } }
+
 
         internal void Log(string message)
         {

--- a/TestFlightCore/TestFlightCore/TestFlight.cs
+++ b/TestFlightCore/TestFlightCore/TestFlight.cs
@@ -542,10 +542,9 @@ namespace TestFlightCore
             string returnPart = "";
             foreach (TestFlightPartData part in partData.Values)
             {
-                float partFlightData = float.Parse(part.GetValue("flightData"));
-                if (partFlightData > flightData)
+                if (part.flightData > flightData)
                 {
-                    flightData = partFlightData;
+                    flightData = part.flightData;
                     returnPart = part.PartName;
                 }
             }
@@ -561,10 +560,9 @@ namespace TestFlightCore
             string returnPart = "";
             foreach (TestFlightPartData part in partData.Values)
             {
-                float partFlightData = float.Parse(part.GetValue("flightData"));
-                if (partFlightData < flightData)
+                if (part.flightData < flightData)
                 {
-                    flightData = partFlightData;
+                    flightData = part.flightData;
                     returnPart = part.PartName;
                 }
             }
@@ -610,7 +608,7 @@ namespace TestFlightCore
         {
             if (partData.ContainsKey(partName))
             {
-                return partData[partName].GetFloat("flightData");
+                return partData[partName].flightData;
             }
             else
                 return -1f;
@@ -619,7 +617,7 @@ namespace TestFlightCore
         public float GetTransferDataForPartName(string partName)
         {
             if (partData.ContainsKey(partName))
-                return partData[partName].GetFloat("transferData");
+                return partData[partName].transferData;
             else
                 return -1f;
         }
@@ -627,7 +625,7 @@ namespace TestFlightCore
         public float GetResearchDataForPartName(string partName)
         {
             if (partData.ContainsKey(partName))
-                return partData[partName].GetFloat("researchData");
+                return partData[partName].researchData;
             else
                 return -1f;
         }
@@ -637,12 +635,12 @@ namespace TestFlightCore
         public void SetFlightDataForPartName(string partName, float data)
         {
             if (partData.ContainsKey(partName))
-                partData[partName].SetValue("flightData", data.ToString());
+                partData[partName].flightData = data;
             else
             {
                 TestFlightPartData newData = new TestFlightPartData();
                 newData.PartName = partName;
-                newData.SetValue("flightData", data.ToString());
+                newData.flightData = data;
                 partData.Add(partName, newData);
             }
         }
@@ -650,12 +648,12 @@ namespace TestFlightCore
         public void SetTransferDataForPartName(string partName, float data)
         {
             if (partData.ContainsKey(partName))
-                partData[partName].SetValue("transferData", data.ToString());
+                partData[partName].transferData = data;
             else
             {
                 TestFlightPartData newData = new TestFlightPartData();
                 newData.PartName = partName;
-                newData.SetValue("transferData", data.ToString());
+                newData.transferData = data;
                 partData.Add(partName, newData);
             }
         }
@@ -663,12 +661,12 @@ namespace TestFlightCore
         public void SetResearchDataForPartName(string partName, float data)
         {
             if (partData.ContainsKey(partName))
-                partData[partName].SetValue("researchData", data.ToString());
+                partData[partName].researchData = data;
             else
             {
                 TestFlightPartData newData = new TestFlightPartData();
                 newData.PartName = partName;
-                newData.SetValue("researchData", data.ToString());
+                newData.researchData = data;
                 partData.Add(partName, newData);
             }
         }
@@ -676,12 +674,12 @@ namespace TestFlightCore
         public void AddFlightDataForPartName(string partName, float data)
         {
             if (partData.ContainsKey(partName))
-                partData[partName].AddValue("flightData", data);
+                partData[partName].flightData += data;
             else
             {
                 TestFlightPartData newData = new TestFlightPartData();
                 newData.PartName = partName;
-                newData.SetValue("flightData", data);
+                newData.flightData = data;
                 partData.Add(partName, newData);
             }
         }
@@ -689,12 +687,12 @@ namespace TestFlightCore
         public void AddTransferDataForPartName(string partName, float data)
         {
             if (partData.ContainsKey(partName))
-                partData[partName].AddValue("transferData", data);
+                partData[partName].transferData += data;
             else
             {
                 TestFlightPartData newData = new TestFlightPartData();
                 newData.PartName = partName;
-                newData.SetValue("transferData", data);
+                newData.transferData = data;
                 partData.Add(partName, newData);
             }
         }
@@ -702,12 +700,12 @@ namespace TestFlightCore
         public void AddResearchDataForPartName(string partName, float data)
         {
             if (partData.ContainsKey(partName))
-                partData[partName].AddValue("researchData", data);
+                partData[partName].researchData += data;
             else
             {
                 TestFlightPartData newData = new TestFlightPartData();
                 newData.PartName = partName;
-                newData.SetValue("researchData", data);
+                newData.researchData = data;
                 partData.Add(partName, newData);
             }
         }
@@ -739,7 +737,7 @@ namespace TestFlightCore
                     TestFlightPartData storedPartData = new TestFlightPartData();
                     storedPartData.Load(partDataNode);
                     partData.Add(storedPartData.PartName, storedPartData);
-                    Log($"Loaded Part Data for {storedPartData.PartName}: {storedPartData.GetFloat("flightData")}");
+                    Log($"Loaded Part Data for {storedPartData.PartName}: {storedPartData.flightData}");
                 }
             }
         }

--- a/TestFlightCore/TestFlightCore/TestFlightCore.cs
+++ b/TestFlightCore/TestFlightCore/TestFlightCore.cs
@@ -127,8 +127,8 @@ namespace TestFlightCore
             { 
                 if (configuration.Equals(string.Empty))
                 {
-                    configuration = "kspPartName = " + TestFlightUtil.GetPartName(this.part);
-                    configuration = configuration + ":" + TestFlightUtil.GetPartName(this.part);
+                    string s = TestFlightUtil.GetPartName(this.part);
+                    configuration = $"kspPartName = {s}:{s}";
                 }
 
                 return configuration; 

--- a/TestFlightCore/TestFlightCore/TestFlightCore.cs
+++ b/TestFlightCore/TestFlightCore/TestFlightCore.cs
@@ -1112,17 +1112,13 @@ namespace TestFlightCore
             if (reliabilityModules != null)
             {
                 float ratedBurnTime = 0f;
-                for (int i = 0, reliabilityModulesCount = reliabilityModules.Count; i < reliabilityModulesCount; i++)
-                {
-                    ITestFlightReliability reliabilityModule = reliabilityModules[i];
+                foreach (var reliabilityModule in reliabilityModules)
                     ratedBurnTime = Mathf.Max(reliabilityModule.GetRatedTime(RatingScope.Cumulative), ratedBurnTime);
-                }
 
-                for (int i = 0, reliabilityModulesCount = reliabilityModules.Count; i < reliabilityModulesCount; i++)
+                foreach (var reliabilityModule in reliabilityModules)
                 {
-                    ITestFlightReliability reliabilityModule = reliabilityModules[i];
                     List<string> infoColl = reliabilityModule.GetTestFlightInfo(ratedBurnTime);
-                    if (infoColl != null)
+                    if (infoColl.Count > 0)
                     {
                         // Don't indent header string
                         infoStrings.Add(infoColl[0]);
@@ -1137,11 +1133,10 @@ namespace TestFlightCore
             List<ITestFlightFailure> failureModules = TestFlightUtil.GetFailureModules(this.part, Alias);
             if (failureModules != null)
             {
-                for (int i = 0, failureModulesCount = failureModules.Count; i < failureModulesCount; i++)
+                foreach (var failureModule in failureModules)
                 {
-                    ITestFlightFailure failureModule = failureModules[i];
                     List<string> infoColl = failureModule.GetTestFlightInfo();
-                    if (infoColl != null && infoColl.Count > 0)
+                    if (infoColl.Count > 0)
                     {
                         // Don't indent header string
                         infoStrings.Add(infoColl[0]);

--- a/TestFlightCore/TestFlightCore/TestFlightCore.cs
+++ b/TestFlightCore/TestFlightCore/TestFlightCore.cs
@@ -73,10 +73,10 @@ namespace TestFlightCore
         // We store the base, or initial, flight data for calculation of Base Failure Rate
         // Momentary Failure Rates are calculated based on modifiers.  Those modifiers
         // are stored per SCOPE and per TRIGGER
-        private List<MomentaryFailureRate> momentaryFailureRates = new List<MomentaryFailureRate>();
-        private List<MomentaryFailureModifier> momentaryFailureModifiers = new List<MomentaryFailureModifier>();
-        private List<ITestFlightFailure> failures = new List<ITestFlightFailure>();
-        private List<string> disabledFailures = new List<string>();
+        private readonly List<MomentaryFailureRate> momentaryFailureRates = new List<MomentaryFailureRate>();
+        private readonly List<MomentaryFailureModifier> momentaryFailureModifiers = new List<MomentaryFailureModifier>();
+        private readonly List<ITestFlightFailure> failures = new List<ITestFlightFailure>();
+        private readonly List<string> disabledFailures = new List<string>();
         private bool hasMajorFailure = false;
         private bool firstStaged;
 
@@ -84,13 +84,13 @@ namespace TestFlightCore
         private float dataRateLimiter = 1.0f;
         private float dataCap = 1.0f;
 
-        private List<ProtoCrewMember> crew = new List<ProtoCrewMember>();
+        private readonly List<ProtoCrewMember> crew = new List<ProtoCrewMember>();
 
         private bool active;
         private bool TestFlightScenarioReady => TestFlightManagerScenario.Instance != null && TestFlightManagerScenario.Instance.isReady;
 
-        private string[] ops = { "=", "!=", "<", "<=", ">", ">=", "<>", "<=>" };
-        private char[] colonSeparator = new char[1] { ':' };
+        private readonly string[] ops = { "=", "!=", "<", "<=", ">", ">=", "<>", "<=>" };
+        private readonly char[] colonSeparator = new char[1] { ':' };
 
         IFlightDataRecorder m_Recorder;
 
@@ -508,7 +508,7 @@ namespace TestFlightCore
             if (TestFlightManagerScenario.Instance != null)
             {
                 TestFlightPartData partData = TestFlightManagerScenario.Instance.GetPartDataForPart(Alias);
-                return partData.GetFloat("flightTime");
+                return partData.flightTime;
             }
             else
                 return 0f;
@@ -545,7 +545,7 @@ namespace TestFlightCore
         {
             if (TestFlightManagerScenario.Instance != null)
             {
-                TestFlightManagerScenario.Instance.GetPartDataForPart(Alias).SetValue("flightTime", flightTime);
+                TestFlightManagerScenario.Instance.GetPartDataForPart(Alias).flightTime = flightTime;
             }
         }
 
@@ -597,12 +597,12 @@ namespace TestFlightCore
             float newFlightTime = -1f;
             if (TestFlightManagerScenario.Instance != null)
             {
-                newFlightTime = TestFlightManagerScenario.Instance.GetPartDataForPart(Alias).GetFloat("flightTime");
+                newFlightTime = TestFlightManagerScenario.Instance.GetPartDataForPart(Alias).flightTime;
                 if (additive)
                     newFlightTime += flightTime;
                 else
                     newFlightTime *= flightTime;
-                TestFlightManagerScenario.Instance.GetPartDataForPart(Alias).SetValue("flightTime", newFlightTime);
+                TestFlightManagerScenario.Instance.GetPartDataForPart(Alias).flightTime = newFlightTime;
             }
 
             return newFlightTime;
@@ -620,7 +620,7 @@ namespace TestFlightCore
             {
                 ProtoCrewMember crewMember = crew[i];
                 int engineerLevel = crewMember.experienceLevel;
-                totalEngineerBonus = totalEngineerBonus + (partEngineerBonus * engineerLevel * globalFlightDataEngineerMultiplier);
+                totalEngineerBonus += partEngineerBonus * engineerLevel * globalFlightDataEngineerMultiplier;
             }
             float engineerModifier = 1.0f + totalEngineerBonus;
 
@@ -728,8 +728,6 @@ namespace TestFlightCore
                     else
                     {
                         Log("Triggering Failure: " + pm.moduleName);
-                        if (failures == null)
-                            failures = new List<ITestFlightFailure>();
                         failures.Add(fm);
                         fm.DoFailure();
                         hasMajorFailure |= fm.GetFailureDetails().severity.ToLowerInvariant() == "major";
@@ -986,7 +984,7 @@ namespace TestFlightCore
                     float partFlightData = TestFlightManagerScenario.Instance.GetFlightDataForPartName(partName);
                     if (partFlightData == 0f)
                         continue;
-                    dataToTransfer = dataToTransfer + ((partFlightData - (partFlightData * generation * techTransferGenerationPenalty)) * branchModifier);
+                    dataToTransfer += ((partFlightData - (partFlightData * generation * techTransferGenerationPenalty)) * branchModifier);
                     generation++;
                 }
             }

--- a/TestFlightCore/TestFlightCore/TestFlightHUD.cs
+++ b/TestFlightCore/TestFlightCore/TestFlightHUD.cs
@@ -51,11 +51,6 @@ namespace TestFlightCore
             WindowMoveEventsEnabled = false;
         }
 
-        internal override void Awake()
-        {
-            base.Awake();
-        }
-
         internal override void OnGUIOnceOnly()
         {
             // Default position and size -- will get proper bounds calculated when needed
@@ -102,7 +97,7 @@ namespace TestFlightCore
             foreach (PartStatus status in masterStatus[currentVessl].allPartsStatus)
             {
                 // We only show failed parts in Flight HUD
-                if (status.failures == null || status.failures.Count <= 0)
+                if (status.failures.Count <= 0)
                     continue;
 
                 GUILayout.BeginHorizontal();

--- a/TestFlightCore/TestFlightCore/TestFlightRnD.cs
+++ b/TestFlightCore/TestFlightCore/TestFlightRnD.cs
@@ -53,7 +53,7 @@ namespace TestFlightCore
                             if (partData != null && prefab != null)
                             {
                                 TestFlightCore core = (TestFlightCore)prefab.Modules.OfType<TestFlightCore>().FirstOrDefault();
-                                float flightData = partData.GetFloat("flightData");
+                                float flightData = partData.flightData;
                                 if (core != null && flightData > core.startFlightData)
                                 {
                                     discount += (int)(((flightData - core.startFlightData) / (core.maxData - core.startFlightData)) * core.scienceDataValue);

--- a/TestFlightReliability_EngineCycle.cs
+++ b/TestFlightReliability_EngineCycle.cs
@@ -47,28 +47,25 @@ namespace TestFlight
         /// <summary>
         /// amount of seconds engine has been running over the entire lifecycle (cumulative)
         /// </summary>
-        [KSPField(isPersistant = true)]
+        [KSPField(isPersistant = true, guiName = "Total run time", groupName = "TestFlight", groupDisplayName = "TestFlight", guiActive = true, guiFormat = "N0")]
         public double engineOperatingTime = 0d;
 
         /// <summary>
         /// amount of second engine has been running since last start/restart
         /// </summary>
-        [KSPField(isPersistant = true)]
+        [KSPField(isPersistant = true, guiName = "Current run time", groupName = "TestFlight", groupDisplayName = "TestFlight", guiActive = true, guiFormat = "N0")]
         public double currentRunTime;
 
         [KSPField(isPersistant = true)]
         public double previousOperatingTime = 0d;
 
-        [KSPField(guiName = "Total run time", groupName = "TestFlight", groupDisplayName = "TestFlight", guiActive = true)]
-        public string totalRunTimeString;
-        [KSPField(guiName = "Current run time", groupName = "TestFlight", groupDisplayName = "TestFlight", guiActive = true)]
-        public string currentRunTimeString;
-        
         public override void OnStart(StartState state)
         {
             base.OnStart(state);
             engine = new EngineModuleWrapper();
             engine.InitWithEngine(this.part, engineID);
+            Fields[nameof(currentRunTime)].guiUnits = $"s/{ratedContinuousBurnTime}s";
+            Fields[nameof(engineOperatingTime)].guiUnits = $"s/{ratedBurnTime}s";
         }
 
         public override double GetBaseFailureRate(float flightData)
@@ -119,9 +116,6 @@ namespace TestFlight
                 return;
 
             UpdateCycle();
-
-            currentRunTimeString = $"{currentRunTime:N0}s/{ratedContinuousBurnTime}s";
-            totalRunTimeString = $"{engineOperatingTime:N0}s/{ratedBurnTime}s";
 
             // We intentionally do NOT call our base class OnUpdate() because that would kick off a second round of 
             // failure checks which is already handled by the main Reliability module that should 


### PR DESCRIPTION
Generalized Performance Tweaks:
Avoid duplicating base method code when calling them from overridden methods
Pay greater attention to string allocations & unguarded stack trace builds
Build constant arrays outside of loops
Avoid extra calls to ToLower() and similar, especially when using StringCompare.OrdinalIgnoreCase
Extract flightData, transferData, researchData, and flightTime from the generalized string dictionary that requires constant parsing/ToString to eliminate GC pressure.
Cache TestFlightCore.Alias Result
Convert PartStatus from struct to class, pass by reference / modify in place
Use part.FindModuleImplementing instead of iterating ourselves.  It caches in latest KSP.

Generalized code pattern tweaks:
Use class initializer for List<T>
Use interpolated strings
Use foreach
Use Dictionary.TryGetValue
Remove unneeded overrides (OnAwake, OnEnable, OnSave) that only ever call the base.
Remove dead code 
Switch to StringCompare.OrdinalIgnoreCase
Don't return null instead of empty Lists in ModuleGetters (Reliability, Failure, etc).

Maintenance Tasks:
Make SettingsEnabled, SettingsAlwaysMaxData common settings KSPFields.
Declare fields [Persistent] and use ConfigNode static methods to save/load objects instead of manually writing/parsing the values to/from the node.
Refactor the Getters/Setters into simpler pattern.  These methods should now be unused outside of TestFlightPartData.cs itself, but remain for compatibility
Declare some fields [Persistent] and use ConfigNode static methods to save/load objects instead of manually writing/parsing the values to/from the node.
Refactor random failure logic
Make tool for hand-written reflection invocations that checked for the TF core, installation status, readiness, then invoked a chosen method

Bugfixes:
Fix GetWorstMomentaryFailureRate to get the worst rate instead of the last rate
Fix some NREs