### PR TITLE
Fix TestFlightAPI.Configuration() for MPEC

### DIFF
--- a/TestFlightAPI/TestFlightAPI/TestFlightAPI.cs
+++ b/TestFlightAPI/TestFlightAPI/TestFlightAPI.cs
@@ -570,8 +570,12 @@ namespace TestFlightAPI
 
         public static string Configuration(Part part)
         {
-            if (!part.Modules.Contains("ModuleEngineConfigs")) return "";
-            string configuration = (string)(part.Modules["ModuleEngineConfigs"].GetType().GetField("configuration").GetValue(part.Modules["ModuleEngineConfigs"]));
+            PartModule mec = part.Modules["ModuleEngineConfigs"];
+            if (mec == null)
+                mec = part.Modules["ModulePatchableEngineConfigs"];
+            if (mec == null) return "";
+            
+            string configuration = (string)(mec.GetType().GetField("configuration").GetValue(part.Modules["ModuleEngineConfigs"]));
             return configuration.ToLower();
         }
 

--- a/makeMeta.py
+++ b/makeMeta.py
@@ -53,4 +53,4 @@ avc = {
 	}
 }
 with open("TestFlight.version", "w") as f:
-	f.write(json.dumps(avc))
+	f.write(json.dumps(avc, indent=4))


### PR DESCRIPTION
Also speed up TestFlightAPI.Configuration() by not finding the same module twice.