### PR TITLE
Scale engine runtime by commanded thrust 

### DIFF
--- a/TestFlightAPI/TestFlightAPI/EngineModuleWrapper.cs
+++ b/TestFlightAPI/TestFlightAPI/EngineModuleWrapper.cs
@@ -250,8 +250,16 @@ public class EngineModuleWrapper
         {
             if (engineType == EngineModuleType.UNKNOWN)
                 return 0f;
-            
-            return Mathf.Lerp(moduleEngine.minThrust, moduleEngine.maxThrust, moduleEngine.currentThrottle);
+            // current thrust / maxThrust * vac_Isp / current_Isp / ispMult / flowMult
+            // var currentThrust = moduleEngine.finalThrust;
+            // var maxThrust = moduleEngine.maxThrust;
+            // var vac_Isp = moduleEngine.atmCurveIsp.Evaluate(0f);
+            // var current_Isp = moduleEngine.realIsp;
+            // var ispMult = moduleEngine.multIsp;
+            // var flowMult = moduleEngine.flowMultiplier;
+
+            return moduleEngine.finalThrust / moduleEngine.maxThrust * moduleEngine.atmCurveIsp.Evaluate(0f) / 
+                   moduleEngine.realIsp / moduleEngine.multIsp / moduleEngine.flowMultiplier;
         }
     }
 

--- a/TestFlightAPI/TestFlightAPI/EngineModuleWrapper.cs
+++ b/TestFlightAPI/TestFlightAPI/EngineModuleWrapper.cs
@@ -244,6 +244,17 @@ public class EngineModuleWrapper
         }
     }
 
+    public float commandedThrust
+    {
+        get
+        {
+            if (engineType == EngineModuleType.UNKNOWN)
+                return 0f;
+            
+            return Mathf.Lerp(moduleEngine.minThrust, moduleEngine.maxThrust, moduleEngine.currentThrottle);
+        }
+    }
+
     public float finalThrust
     {
         get

--- a/TestFlightReliability_EngineCycle.cs
+++ b/TestFlightReliability_EngineCycle.cs
@@ -30,7 +30,13 @@ namespace TestFlight
         /// </summary>
         [KSPField]
         public float ratedBurnTime = 0f;
-
+        
+        /// <summary>
+        /// Multiplier to how much time is added to the engine's runTime based on set throttle position
+        /// </summary>
+        [KSPField]
+        public FloatCurve thrustModifier = null;
+        
         /// <summary>
         /// maximum rated continuous burn time between restarts
         /// </summary>
@@ -94,8 +100,10 @@ namespace TestFlight
                     // engine is running
                     
                     // increase both continuous and cumulative run times
-                    currentRunTime += deltaTime; // continuous
-                    engineOperatingTime += deltaTime; // cumulative
+                    // add burn time based on time passed, optionally modified by the thrust
+                    float actualThrustModifier = thrustModifier.Evaluate(engine.commandedThrust);
+                    currentRunTime += deltaTime * actualThrustModifier; // continuous
+                    engineOperatingTime += deltaTime * actualThrustModifier; // cumulative
                     
 
                     // calculate total failure rate modifier
@@ -276,6 +284,12 @@ namespace TestFlight
             {
                 continuousCycle = new FloatCurve();
                 continuousCycle.Add(0f, 1f);
+            }
+
+            if (thrustModifier == null)
+            {
+                thrustModifier = new FloatCurve();
+                thrustModifier.Add(0f, 1f);                
             }
 
         }


### PR DESCRIPTION

TestFlightReliability_EngineCycle can now optionally modify current & accumulated burn time based on the engine's commanded thrust level. This is defined as a modifier curve using the FloatCurve `thrustModifier`