### PR TITLE
Fix for kOS ignoring ignition failures

### DIFF
--- a/TestFlightAPI/TestFlightAPI/EngineModuleWrapper.cs
+++ b/TestFlightAPI/TestFlightAPI/EngineModuleWrapper.cs
@@ -305,6 +305,22 @@ public class EngineModuleWrapper
         moduleEngine.DeactivatePowerFX();
     }
 
+    // Disable restarts for failed engines
+    public void DisableRestart()
+    {
+        if (engineType == EngineModuleType.UNKNOWN)
+            return;
+
+        // Need to disable this to prevent other mods from restarting the engine.
+        moduleEngine.allowRestart = false;
+
+        // For some reason, need to disable GUI as well
+        Events["Activate"].active = false;
+        Events["Shutdown"].active = false;
+        Events["Activate"].guiActive = false;
+        Events["Shutdown"].guiActive = false;
+    }
+
     // Reduce fuel flow
     public void SetFuelFlowMult(float multiplier)
     {

--- a/TestFlightFailure_IgnitionFail.cs
+++ b/TestFlightFailure_IgnitionFail.cs
@@ -301,16 +301,13 @@ namespace TestFlight
                 EngineHandler engine = engines[i];
                 if (engine.failEngine)
                 {
-                    engine.engine.Shutdown();
-
                     if (severity.ToLowerInvariant() == "major")
                     {
-                        // For some reason, need to disable GUI as well
-                        engine.engine.Events["Activate"].active = false;
-                        engine.engine.Events["Shutdown"].active = false;
-                        engine.engine.Events["Activate"].guiActive = false;
-                        engine.engine.Events["Shutdown"].guiActive = false;
+                        engine.engine.DisableRestart();
                     }
+
+                    engine.engine.Shutdown();
+
                     if ((restoreIgnitionCharge) || (this.vessel.situation == Vessel.Situations.PRELAUNCH) )
                         RestoreIgnitor();
                     engines[i].failEngine = false;

--- a/TestFlightFailure_ShutdownEngine.cs
+++ b/TestFlightFailure_ShutdownEngine.cs
@@ -33,11 +33,7 @@ namespace TestFlight
                 {
                     numIgnitionsToRemove = -1;
 
-                    // For some reason, need to disable GUI as well
-                    engine.engine.Events["Activate"].active = false;
-                    engine.engine.Events["Shutdown"].active = false;
-                    engine.engine.Events["Activate"].guiActive = false;
-                    engine.engine.Events["Shutdown"].guiActive = false;
+                    engine.engine.DisableRestart();
 
                     engine.engine.failed = true;
                     engine.engine.failMessage = failureTitle;


### PR DESCRIPTION
kOS (and potentially other mods) can bypass failed engines because they ignore the events for activating engines, instead calling `ModuleEngines.Activate()` directly. This fix disables the engine using ModuleEngines preventing this behaviour.

This might need a fix in KCT to allow recovered engines to ignite.