### PR TITLE
Add additional TestFlight data to editor and flight PAW

### DIFF
--- a/TestFlightCore/TestFlightCore/TestFlightCore.cs
+++ b/TestFlightCore/TestFlightCore/TestFlightCore.cs
@@ -1107,6 +1107,14 @@ namespace TestFlightCore
             enabled = true;
             active = true;
 
+            if (TestFlightScenarioReady && HighLogic.LoadedSceneIsEditor)
+            {
+                float data = TestFlightManagerScenario.Instance.SettingsAlwaysMaxData
+                            ? maxData : Mathf.Max(0, TestFlightManagerScenario.Instance.GetFlightDataForPartName(Alias));
+
+                InitializeFlightData(data);
+            }
+
             List<PartModule> tfPartModules = TestFlightAPI.TestFlightUtil.GetAllTestFlightModulesForPart(part);
             foreach (var partModule in tfPartModules)
             {
@@ -1121,7 +1129,7 @@ namespace TestFlightCore
                 ITestFlightReliability reliability = partModule as ITestFlightReliability;
                 if (reliability != null)
                     reliability.SetActiveConfig(Alias);
-                
+
                 // TestFlightFailure
                 ITestFlightFailure failure = partModule as ITestFlightFailure;
                 if (failure != null)
@@ -1135,14 +1143,6 @@ namespace TestFlightCore
             for (int i = 0; i < testFlightModules.Count; i++)
             {
                 testFlightModules[i].enabled = enabled;
-            }
-
-
-            if (TestFlightScenarioReady && HighLogic.LoadedSceneIsEditor)
-            {
-                float data = TestFlightManagerScenario.Instance.SettingsAlwaysMaxData
-                            ? maxData : Mathf.Max(0, TestFlightManagerScenario.Instance.GetFlightDataForPartName(Alias));
-                InitializeFlightData(data);
             }
         }
 

--- a/TestFlightFailure_Engine.cs
+++ b/TestFlightFailure_Engine.cs
@@ -125,8 +125,8 @@ namespace TestFlight
                 {
                     foreach (var handler in engines)
                     {
-                        handler.engine.Status = "Failed";
-                        handler.engine.StatusL2 = failureTitle;
+                        handler.engine.Status = "<color=orange>Failed</color>";
+                        handler.engine.StatusL2 = $"<color=orange>{failureTitle}</color>";
                     }
                 }
             }

--- a/TestFlightFailure_IgnitionFail.cs
+++ b/TestFlightFailure_IgnitionFail.cs
@@ -49,6 +49,11 @@ namespace TestFlight
         [KSPField(guiName = "Last Restart", groupName = "TestFlightDebug", groupDisplayName = "TestFlightDebug", guiActive = true)]
         private string restartRollString;
 
+        [KSPField(guiName = "Current ignition chance", groupName = "TestFlight", groupDisplayName = "TestFlight", guiActiveEditor = true, guiFormat = "P2")]
+        public float currentIgnitionChance = 0f;
+
+        [KSPField(guiName = "Max ignition chance", groupName = "TestFlight", groupDisplayName = "TestFlight", guiActiveEditor = true, guiFormat = "P2")]
+        public float maxIgnitionChance = 0f;
 
         private bool hasRestartWindow;
         private bool engineHasRun;
@@ -421,7 +426,8 @@ namespace TestFlight
                 restartWindowPenalty.Add(0f, 1f);
                 hasRestartWindow = false;
             }
-            
+
+            GetIgnitionChance(ref currentIgnitionChance, ref maxIgnitionChance);            
         }
 
         public override string GetModuleInfo(string configuration)
@@ -494,6 +500,46 @@ namespace TestFlight
 
             return infoStrings;
         }
+
+        /// <summary>
+        /// Gets current and max data ignition chance for use in engine PAW
+        /// </summary>
+        /// <param name="currentIgnitionChance"></param>
+        /// <param name="maxIgnitionChance"></param>
+        private void GetIgnitionChance(ref float currentIgnitionChance, ref float maxIgnitionChance)
+        {
+            if (core == null)
+            {
+                Log("Core is null");
+                return;
+            }
+
+            foreach (var failureModule in TestFlightUtil.GetFailureModules(this.part, core.Alias))
+            {
+                TestFlightFailure_IgnitionFail ignitionFailure = failureModule as TestFlightFailure_IgnitionFail;
+
+                if (ignitionFailure != null)
+                {
+                    FloatCurve curve = ignitionFailure.baseIgnitionChance;
+
+                    if (curve == null)
+                    {
+                        Log("Curve is null");
+                        return;
+                    }
+
+                    float flightData = core.GetFlightData();
+                    if (flightData < 0f)
+                        flightData = 0f;
+
+                    currentIgnitionChance = curve.Evaluate(flightData);
+                    maxIgnitionChance = curve.Evaluate(curve.maxTime);
+
+                    return;
+                }
+            }
+        }
+
     }
 }
 


### PR DESCRIPTION
Goal is to add more engine PAW data similarly to how TestLite did it, so user doesn't have to use TestFlight's editor window.

- Editor:
     - Add current and max flight data
     - Add current and max data reliability
     - Add current and max data ignition chance
     - Rated burn time: additionally display time in minutes for longer burn times (>60 sec), for ease of conversion

- Flight:
     - Add current and max flight data
     - Color engine failures in orange

Editor:
![1_editor](https://user-images.githubusercontent.com/72734856/200114122-0edb47cf-98b4-4aff-931c-bf5f6057e75a.png)

Flight:
![2_flight](https://user-images.githubusercontent.com/72734856/200114132-cb734e67-91f5-4370-9d67-9b53d78d7b6a.png)

Flight failures:
![3_flight_failure](https://user-images.githubusercontent.com/72734856/200114137-e73d0504-0399-490d-9882-cc1397f1dae3.png)
![4_flight_failure](https://user-images.githubusercontent.com/72734856/200114139-0dd13666-eae8-4626-8cb0-a7a26540a077.png)
