### PR TITLE
Add additional TestFlight data to editor and flight PAW

### DIFF
--- a/TestFlightCore/TestFlightCore/TestFlightCore.cs
+++ b/TestFlightCore/TestFlightCore/TestFlightCore.cs
@@ -1107,6 +1107,13 @@ namespace TestFlightCore
             enabled = true;
             active = true;
 
+            if (TestFlightScenarioReady && HighLogic.LoadedSceneIsEditor)
+            {
+                float data = TestFlightManagerScenario.Instance.SettingsAlwaysMaxData
+                            ? maxData : Mathf.Max(0, TestFlightManagerScenario.Instance.GetFlightDataForPartName(Alias));
+                InitializeFlightData(data);
+            }
+
             List<PartModule> tfPartModules = TestFlightAPI.TestFlightUtil.GetAllTestFlightModulesForPart(part);
             foreach (var partModule in tfPartModules)
             {
@@ -1135,15 +1142,7 @@ namespace TestFlightCore
             for (int i = 0; i < testFlightModules.Count; i++)
             {
                 testFlightModules[i].enabled = enabled;
-            }
-
-
-            if (TestFlightScenarioReady && HighLogic.LoadedSceneIsEditor)
-            {
-                float data = TestFlightManagerScenario.Instance.SettingsAlwaysMaxData
-                            ? maxData : Mathf.Max(0, TestFlightManagerScenario.Instance.GetFlightDataForPartName(Alias));
-                InitializeFlightData(data);
-            }
+            }            
         }
 
         public float GetMaximumRnDData()

--- a/TestFlightFailure_Engine.cs
+++ b/TestFlightFailure_Engine.cs
@@ -125,8 +125,8 @@ namespace TestFlight
                 {
                     foreach (var handler in engines)
                     {
-                        handler.engine.Status = "Failed";
-                        handler.engine.StatusL2 = failureTitle;
+                        handler.engine.Status = "<color=orange>Failed</color>";
+                        handler.engine.StatusL2 = $"<color=orange>{failureTitle}</color>";
                     }
                 }
             }

--- a/TestFlightReliability_EngineCycle.cs
+++ b/TestFlightReliability_EngineCycle.cs
@@ -28,7 +28,7 @@ namespace TestFlight
         /// <summary>
         /// maximum rated cumulative run time of the engine over the entire lifecycle
         /// </summary>
-        [KSPField(guiName = "Rated Burn Time", groupName = "TestFlight", groupDisplayName = "TestFlight", guiActiveEditor = true, guiUnits = "s")]
+        [KSPField(guiName = "Rated Cumulative Burn Time", groupName = "TestFlight", groupDisplayName = "TestFlight", guiActiveEditor = true, guiUnits = "s")]
         public float ratedBurnTime = 0f;
         
         /// <summary>
@@ -40,7 +40,7 @@ namespace TestFlight
         /// <summary>
         /// maximum rated continuous burn time between restarts
         /// </summary>
-        [KSPField(guiName = "Rated Continuous Burn Time", groupName = "TestFlight", groupDisplayName = "TestFlight", guiUnits = "s")]
+        [KSPField(guiName = "Rated Continuous Burn Time", groupName = "TestFlight", groupDisplayName = "TestFlight", guiActiveEditor = true, guiUnits = "s")]
         public float ratedContinuousBurnTime;
         
         [KSPField]
@@ -204,14 +204,31 @@ namespace TestFlight
                 ratedContinuousBurnTime = ratedBurnTime;
             }
 
+            // hide continuous burn time if it's the same as cumulative
+            if (ratedBurnTime == ratedContinuousBurnTime)
+            {
+                Fields[nameof(ratedBurnTime)].guiName = "Rated Burn Time";
+                Fields[nameof(ratedContinuousBurnTime)].guiActiveEditor = false;
+            }
+            else
+            {
+                Fields[nameof(ratedBurnTime)].guiName = "Rated Cumulative Burn Time";
+                Fields[nameof(ratedContinuousBurnTime)].guiActiveEditor = true;
+            }
+
             GetFlightData(ref flightData, ref maxFlightData);
             GetReliability(ratedBurnTime, ref currentReliability, ref maxReliability);
 
-            // add display in minutes and seconds for longer burn times
+            // add display in hours, minutes and seconds for longer burn times
             if (ratedBurnTime >= 60)
                 Fields[nameof(ratedBurnTime)].guiUnits = $"s ({TestFlightUtil.FormatTime(ratedBurnTime, TestFlightUtil.TIMEFORMAT.SHORT_IDENTIFIER, false)})";
             else
                 Fields[nameof(ratedBurnTime)].guiUnits = $"s";
+
+            if (ratedContinuousBurnTime >= 60)
+                Fields[nameof(ratedContinuousBurnTime)].guiUnits = $"s ({TestFlightUtil.FormatTime(ratedContinuousBurnTime, TestFlightUtil.TIMEFORMAT.SHORT_IDENTIFIER, false)})";
+            else
+                Fields[nameof(ratedContinuousBurnTime)].guiUnits = $"s";
         }
 
         public override string GetModuleInfo(string configuration, float reliabilityAtTime)


### PR DESCRIPTION
Goal is to add more engine PAW data similarly to how TestLite did it, so user doesn't have to use TestFlight's editor window.

Editor:
- Add rated burn time; additionally display time in minutes for longer burn times (>60 sec), for ease of conversion Add current and max flight data
- Add current and max data MTBF
- Add current and max data reliability
- Add current and max data ignition chance

Flight:

- Add current and max flight data
- Add MTBF
- Color engine failures in orange

Editor:
![addPawEditor](https://user-images.githubusercontent.com/72734856/203869790-09490032-2b23-4673-bef4-6ed76197a3e5.png)

Flight:
![addPawFlight](https://user-images.githubusercontent.com/72734856/203869808-2bfb3a34-d1eb-4407-96f3-ac9bba0280d0.png)

Flight failure:
![addPawOrangeFailure](https://user-images.githubusercontent.com/72734856/203869827-cdd2d72f-8a85-4d87-9bd6-98b3efbf5809.png)