### PR TITLE
Add additional TestFlight data to editor and flight PAW (#257)

### DIFF
--- a/TestFlightCore/TestFlightCore/TestFlightCore.cs
+++ b/TestFlightCore/TestFlightCore/TestFlightCore.cs
@@ -1107,6 +1107,13 @@ namespace TestFlightCore
             enabled = true;
             active = true;
 
+            if (TestFlightScenarioReady && HighLogic.LoadedSceneIsEditor)
+            {
+                float data = TestFlightManagerScenario.Instance.SettingsAlwaysMaxData
+                            ? maxData : Mathf.Max(0, TestFlightManagerScenario.Instance.GetFlightDataForPartName(Alias));
+                InitializeFlightData(data);
+            }
+
             List<PartModule> tfPartModules = TestFlightAPI.TestFlightUtil.GetAllTestFlightModulesForPart(part);
             foreach (var partModule in tfPartModules)
             {
@@ -1135,15 +1142,7 @@ namespace TestFlightCore
             for (int i = 0; i < testFlightModules.Count; i++)
             {
                 testFlightModules[i].enabled = enabled;
-            }
-
-
-            if (TestFlightScenarioReady && HighLogic.LoadedSceneIsEditor)
-            {
-                float data = TestFlightManagerScenario.Instance.SettingsAlwaysMaxData
-                            ? maxData : Mathf.Max(0, TestFlightManagerScenario.Instance.GetFlightDataForPartName(Alias));
-                InitializeFlightData(data);
-            }
+            }            
         }
 
         public float GetMaximumRnDData()

--- a/TestFlightFailure_Engine.cs
+++ b/TestFlightFailure_Engine.cs
@@ -125,8 +125,8 @@ namespace TestFlight
                 {
                     foreach (var handler in engines)
                     {
-                        handler.engine.Status = "Failed";
-                        handler.engine.StatusL2 = failureTitle;
+                        handler.engine.Status = "<color=orange>Failed</color>";
+                        handler.engine.StatusL2 = $"<color=orange>{failureTitle}</color>";
                     }
                 }
             }

--- a/TestFlightReliability_EngineCycle.cs
+++ b/TestFlightReliability_EngineCycle.cs
@@ -24,11 +24,11 @@ namespace TestFlight
         /// </summary>
         [KSPField]
         public FloatCurve continuousCycle;
-        
+
         /// <summary>
         /// maximum rated cumulative run time of the engine over the entire lifecycle
         /// </summary>
-        [KSPField]
+        [KSPField(guiName = "Rated Cumulative Burn Time", groupName = "TestFlight", groupDisplayName = "TestFlight", guiActiveEditor = true, guiUnits = "s")]
         public float ratedBurnTime = 0f;
         
         /// <summary>
@@ -36,11 +36,11 @@ namespace TestFlight
         /// </summary>
         [KSPField]
         public FloatCurve thrustModifier = null;
-        
+
         /// <summary>
         /// maximum rated continuous burn time between restarts
         /// </summary>
-        [KSPField]
+        [KSPField(guiName = "Rated Continuous Burn Time", groupName = "TestFlight", groupDisplayName = "TestFlight", guiActiveEditor = true, guiUnits = "s")]
         public float ratedContinuousBurnTime;
         
         [KSPField]
@@ -53,25 +53,50 @@ namespace TestFlight
         /// <summary>
         /// amount of seconds engine has been running over the entire lifecycle (cumulative)
         /// </summary>
-        [KSPField(isPersistant = true, guiName = "Total run time", groupName = "TestFlight", groupDisplayName = "TestFlight", guiActive = true, guiFormat = "N0")]
+        [KSPField(isPersistant = true, guiName = "Total Run Time", groupName = "TestFlight", groupDisplayName = "TestFlight", guiActive = true, guiFormat = "N0")]
         public double engineOperatingTime = 0d;
 
         /// <summary>
         /// amount of second engine has been running since last start/restart
         /// </summary>
-        [KSPField(isPersistant = true, guiName = "Current run time", groupName = "TestFlight", groupDisplayName = "TestFlight", guiActive = true, guiFormat = "N0")]
+        [KSPField(isPersistant = true, guiName = "Current Run Time", groupName = "TestFlight", groupDisplayName = "TestFlight", guiActive = true, guiFormat = "N0")]
         public double currentRunTime;
 
         [KSPField(isPersistant = true)]
         public double previousOperatingTime = 0d;
+
+        /// <summary>
+        /// Current MTBF
+        /// </summary>
+        [KSPField(guiName = "Mean Time Between Failures", groupName = "TestFlight", groupDisplayName = "TestFlight", guiActive = true)]
+        public string currentMTBF;
+
+        /// <summary>
+        /// Current flight data
+        /// </summary>
+        [KSPField(guiName = "Flight Data", groupName = "TestFlight", groupDisplayName = "TestFlight", guiActive = true, guiActiveEditor = true, guiFormat = "F0")]
+        public double flightData = 0d;
+
+        private double maxFlightData = 0d;
+
+        [KSPField(guiName = "Current Reliability", groupName = "TestFlight", groupDisplayName = "TestFlight", guiActiveEditor = true, guiFormat = "P2")]
+        public double currentReliability = 0f;
+
+        [KSPField(guiName = "Reliability at Max Data", groupName = "TestFlight", groupDisplayName = "TestFlight", guiActiveEditor = true, guiFormat = "P2")]
+        public double maxReliability = 0f;
 
         public override void OnStart(StartState state)
         {
             base.OnStart(state);
             engine = new EngineModuleWrapper();
             engine.InitWithEngine(this.part, engineID);
-            Fields[nameof(currentRunTime)].guiUnits = $"s/{ratedContinuousBurnTime}s";
-            Fields[nameof(engineOperatingTime)].guiUnits = $"s/{ratedBurnTime}s";
+
+            Fields[nameof(currentRunTime)].guiUnits = $"s / {ratedContinuousBurnTime}s";
+            Fields[nameof(engineOperatingTime)].guiUnits = $"s / {ratedBurnTime}s";
+
+            // update engine PAW with flight data
+            GetFlightData(ref flightData, ref maxFlightData);
+            GetMTBF();            
         }
 
         public override double GetBaseFailureRate(float flightData)
@@ -84,9 +109,12 @@ namespace TestFlight
         {
             double currentTime = Planetarium.GetUniversalTime();
             double deltaTime = (currentTime - previousOperatingTime) / 1d;
+
+            // update run times every second
             if (deltaTime >= 1d)
             {
                 previousOperatingTime = currentTime;
+
                 // Is our engine running?
                 if (!core.IsPartOperating())
                 {
@@ -113,6 +141,9 @@ namespace TestFlight
                     core.SetTriggerMomentaryFailureModifier("EngineCycle", cumulativeModifier * continuousModifier, this);
                 }
             }
+
+            GetFlightData(ref flightData);
+            GetMTBF();
         }
 
         public override void OnUpdate()
@@ -172,6 +203,32 @@ namespace TestFlight
             {
                 ratedContinuousBurnTime = ratedBurnTime;
             }
+
+            // hide continuous burn time if it's the same as cumulative
+            if (ratedBurnTime == ratedContinuousBurnTime)
+            {
+                Fields[nameof(ratedBurnTime)].guiName = "Rated Burn Time";
+                Fields[nameof(ratedContinuousBurnTime)].guiActiveEditor = false;
+            }
+            else
+            {
+                Fields[nameof(ratedBurnTime)].guiName = "Rated Cumulative Burn Time";
+                Fields[nameof(ratedContinuousBurnTime)].guiActiveEditor = true;
+            }
+
+            GetFlightData(ref flightData, ref maxFlightData);
+            GetReliability(ratedBurnTime, ref currentReliability, ref maxReliability);
+
+            // add display in hours, minutes and seconds for longer burn times
+            if (ratedBurnTime >= 60)
+                Fields[nameof(ratedBurnTime)].guiUnits = $"s ({TestFlightUtil.FormatTime(ratedBurnTime, TestFlightUtil.TIMEFORMAT.SHORT_IDENTIFIER, false)})";
+            else
+                Fields[nameof(ratedBurnTime)].guiUnits = $"s";
+
+            if (ratedContinuousBurnTime >= 60)
+                Fields[nameof(ratedContinuousBurnTime)].guiUnits = $"s ({TestFlightUtil.FormatTime(ratedContinuousBurnTime, TestFlightUtil.TIMEFORMAT.SHORT_IDENTIFIER, false)})";
+            else
+                Fields[nameof(ratedContinuousBurnTime)].guiUnits = $"s";
         }
 
         public override string GetModuleInfo(string configuration, float reliabilityAtTime)
@@ -314,6 +371,109 @@ namespace TestFlight
                 infoStrings.Add($"<b>Rated Run Time</b>: {TestFlightUtil.FormatTime(ratedBurnTime, TestFlightUtil.TIMEFORMAT.SHORT_IDENTIFIER, true)}");
             }
             return infoStrings;
+        }
+
+        /// <summary>
+        /// Gets MTBF for use in engine PAW.
+        /// </summary>
+        private void GetMTBF()
+        {
+            if (core == null)
+            {
+                Log("Core is null");
+                return;
+            }
+
+            FloatCurve curve = core.GetBaseReliabilityCurve();
+
+            if (curve == null)
+            {
+                Log("Curve is null");
+                return;
+            }
+            
+            MomentaryFailureRate momentaryFailureRate = core.GetWorstMomentaryFailureRate();
+            if (!momentaryFailureRate.valid) return;
+
+            currentMTBF = core.FailureRateToMTBFString(momentaryFailureRate.failureRate, TestFlightUtil.MTBFUnits.SECONDS, true, 60);
+        }
+
+
+        /// <summary>
+        /// Gets flight data for use in engine PAW. Does NOT modify flight data.
+        /// </summary>
+        /// <param name="flightData"></param>
+        /// <param name="maxFlightData"></param>
+        private void GetFlightData(ref double flightData, ref double maxFlightData)
+        {
+            if (core == null)
+            {
+                Log("Core is null");
+                return;
+            }
+
+            maxFlightData = core.GetMaximumData();
+            Fields[nameof(flightData)].guiUnits = $" du / {maxFlightData:F0} du";
+
+            flightData = Mathf.Max(0f, core.GetFlightData());
+            float fd_test1 = TestFlightManagerScenario.Instance.GetFlightDataForPartName(core.Alias);
+
+            if (flightData > maxFlightData)
+                flightData = maxFlightData;
+        }
+
+        /// <summary>
+        /// Gets flight data for use in engine PAW. Does NOT modify flight data.
+        /// </summary>
+        /// <param name="flightData"></param>
+        private void GetFlightData(ref double flightData)
+        {
+            if (core == null)
+            {
+                Log("Core is null");
+                return;
+            }
+
+            flightData = Mathf.Max(0f, core.GetFlightData());
+
+            if (flightData > maxFlightData)
+                flightData = maxFlightData;
+        }
+
+        /// <summary>
+        /// Gets current and max data realibility for use in engine PAW
+        /// </summary>
+        /// <param name="reliabilityAtTime"></param>
+        private void GetReliability(float reliabilityAtTime, ref double currentReliability, ref double maxReliability)
+        {
+            if (core == null)
+            {
+                Log("Core is null");
+                return;
+            }
+
+            FloatCurve curve = core.GetBaseReliabilityCurve();
+
+            if (curve == null)
+            {
+                Log("Curve is null");
+                return;
+            }
+
+            float flightData = Mathf.Max(0f, core.GetFlightData());
+            double currentFailRate = curve.Evaluate(flightData);
+            double maxFailRate = curve.Evaluate(curve.maxTime);
+
+            currentReliability = TestFlightUtil.FailureRateToReliability(currentFailRate, reliabilityAtTime);
+            maxReliability = TestFlightUtil.FailureRateToReliability(maxFailRate, reliabilityAtTime);
+
+            // this also updates MTBF during initial flight scene load
+            currentMTBF = core.FailureRateToMTBFString(currentFailRate, TestFlightUtil.MTBFUnits.SECONDS, true, 60);            
+            
+            string maxMTBF = core.FailureRateToMTBFString(maxFailRate, TestFlightUtil.MTBFUnits.SECONDS, true, 60);
+
+            Fields[nameof(currentReliability)].guiUnits = $", MTBF: {currentMTBF}";
+            Fields[nameof(maxReliability)].guiUnits = $", MTBF: {maxMTBF}";
         }
     }
 }


### PR DESCRIPTION
* Add additional TestFlight data to editor and flight PAW

Goal is to add more engine PAW data similarly to how TestLite did it, so user doesn't have to use TestFlight's editor window.

Editor:

Add rated burn time; additionally display time in minutes for longer burn times (>60 sec), for ease of conversion Display Continuous Burn Time rating for engine configs that have different continuous and cumulative values. Add current and max flight data
Add current and max data MTBF
Add current and max data reliability
Add current and max data ignition chance

Flight:

Add current and max flight data
Add MTBF
Color engine failures in orange