### PR TITLE
Fix SRMs not having ignition chance in editor PAW

### DIFF
--- a/TestFlightFailure_IgnitionFail.cs
+++ b/TestFlightFailure_IgnitionFail.cs
@@ -507,8 +507,7 @@ namespace TestFlight
         {
             if (core == null)
             {
-                Log("Core is null");
-                return;
+                core = TestFlightUtil.GetCore(part);
             }
 
             foreach (var failureModule in TestFlightUtil.GetFailureModules(this.part, core.Alias))


### PR DESCRIPTION
This fixes SRMs having current and max ignition chance set to 0% when first loading a part.

Issue was 'core' being null when first selecting the part from the part menu (worked ok when changing configs). Although I'm not certain why that only happens for SRMs and never for liquid fuel engines.
