### PR TITLE
Fix du loss when switching to an older vessel

### DIFF
--- a/TestFlightCore/TestFlightCore/TestFlightCore.cs
+++ b/TestFlightCore/TestFlightCore/TestFlightCore.cs
@@ -852,8 +852,11 @@ namespace TestFlightCore
                 
             currentFlightData = Mathf.Min(maxData, flightData);
             initialFlightData = Mathf.Min(maxData, flightData + researchData + transferData);
-
-            TestFlightManagerScenario.Instance.SetFlightDataForPartName(Alias, flightData);
+            
+            // Keep scenario flight data unchanged if it's higher than this part's flight data
+            float savedFlightData = TestFlightManagerScenario.Instance.GetFlightDataForPartName(Alias);
+            TestFlightManagerScenario.Instance.SetFlightDataForPartName(Alias, Mathf.Max(flightData, savedFlightData));
+            
             missionStartTime = Planetarium.GetUniversalTime();
 
             initialized |= HighLogic.LoadedSceneIsFlight;

--- a/TestFlightFailure_IgnitionFail.cs
+++ b/TestFlightFailure_IgnitionFail.cs
@@ -507,8 +507,7 @@ namespace TestFlight
         {
             if (core == null)
             {
-                Log("Core is null");
-                return;
+                core = TestFlightUtil.GetCore(part);
             }
 
             foreach (var failureModule in TestFlightUtil.GetFailureModules(this.part, core.Alias))


### PR DESCRIPTION
Don't save du amount from current part if it's lower than a previously remembered value
