### PR TITLE
Fix in-flight NRE spam when TF is disabled

### DIFF
--- a/TestFlightAPI/TestFlightAPI/TestFlightAPI.cs
+++ b/TestFlightAPI/TestFlightAPI/TestFlightAPI.cs
@@ -288,8 +288,6 @@ namespace TestFlightAPI
             ITestFlightCore core = null;
             if (part != null)
                 core = part.FindModuleImplementing<ITestFlightCore>();
-            if (core != null && !core.TestFlightEnabled)
-                core = null;
             Profiler.EndSample();
             return core;
         }


### PR DESCRIPTION
Fixes https://github.com/KSP-RO/TestFlight/issues/273

Tested in dev environment - in career and in sandbox, when TS is enabled and disabled, with a liquid fuel engine and with SRBs. Seems to work correctly.