### PR TITLE
Award DU upon engine ignition

### DIFF
--- a/TestFlightFailure_IgnitionFail.cs
+++ b/TestFlightFailure_IgnitionFail.cs
@@ -275,6 +275,15 @@ namespace TestFlight
                         }
                         else
                         {
+                            if (core.GetFlightData() == initialFlightData) //Only award DU on the first ignition of each flight.
+                            {
+                                float ignitionDU = core.GetMaximumData() / 40;
+                                if (verboseDebugging)
+                                {
+                                    Log($"IginitionFail Awarding successful ignition DU: {ignitionDU:F4}");
+                                }
+                                core.ModifyFlightData(ignitionDU, true); //Award DU for first successful ignition
+                            }
                             engineData.hasBeenRun = true;
                         }
                     }


### PR DESCRIPTION
Successfully igniting an engine will now award 1/40th of TestFlight's configured maximum DU.
This DU will only be awarded upon the first ignition of the engine during a flight. Subsequent ignitions on the same flight award no extra DU. If a vessel is recovered and re-flown, the first ignition on that flight will once again award DU.
This corrects the situation in which engines with high rated burn times gain very little DU when used many times on successful missions in low burn time applications. This is especially punishing if the engine has a low initial ignition chance but a much improved ignition chance at high DU. With this PR you need not suffer an engine failure first to substantially improve reliability.

- [x] PR being applied to the correct **Feature Branch** or **dev**
- [x] PR is **not** being sent to **master**
