### PR TITLE
Easier Method to Close Window and Small UX Bug Fixes

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -50,7 +50,12 @@ jobs:
           cp -v ${GITHUB_WORKSPACE}/TestFlightAPI/TestFlightAPI/bin/Release/TestFlightAPI.dll ${GITHUB_WORKSPACE}/GameData/TestFlight/Plugins/TestFlightAPI.dll
           cp -v ${GITHUB_WORKSPACE}/TestFlightCore/TestFlightCore/bin/Release/TestFlightCore.dll ${GITHUB_WORKSPACE}/GameData/TestFlight/Plugins/TestFlightCore.dll
           cp -v ${GITHUB_WORKSPACE}/TestFlightContracts/bin/Release/TestFlightContracts.dll ${GITHUB_WORKSPACE}/GameData/TestFlight/Plugins/TestFlightContracts.dll
-        
+
+      - name: Remove excess DLLs
+        uses: KSP-RO/BuildTools/remove-excess-dlls@master
+        with:
+          path: ${GITHUB_WORKSPACE}/GameData/
+
       - name: Setup python
         uses: actions/setup-python@v2
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,12 @@ jobs:
           cp -v ${GITHUB_WORKSPACE}/TestFlightAPI/TestFlightAPI/bin/Release/TestFlightAPI.dll ${GITHUB_WORKSPACE}/GameData/TestFlight/Plugins/TestFlightAPI.dll
           cp -v ${GITHUB_WORKSPACE}/TestFlightCore/TestFlightCore/bin/Release/TestFlightCore.dll ${GITHUB_WORKSPACE}/GameData/TestFlight/Plugins/TestFlightCore.dll
           cp -v ${GITHUB_WORKSPACE}/TestFlightContracts/bin/Release/TestFlightContracts.dll ${GITHUB_WORKSPACE}/GameData/TestFlight/Plugins/TestFlightContracts.dll
-        
+
+      - name: Remove excess DLLs
+        uses: KSP-RO/BuildTools/remove-excess-dlls@master
+        with:
+          path: ${GITHUB_WORKSPACE}/GameData/
+
       - name: Setup python
         uses: actions/setup-python@v2
         

--- a/GameData/TestFlight/TestFlight.version
+++ b/GameData/TestFlight/TestFlight.version
@@ -5,13 +5,13 @@
 "KSP_VERSION":
 	{
 	"MAJOR": 1,
-	"MINOR": 8,
-	"PATCH": 1
+	"MINOR": 12,
+	"PATCH": 3
 	},
 "VERSION":
 	{
 	"MAJOR": 2,
-	"MINOR": 0,
+	"MINOR": 10,
 	"PATCH": 0,
 	"BUILD": 0
 	},
@@ -25,9 +25,9 @@
 "KSP_VERSION_MAX":
 	{
 	"MAJOR": 1,
-	"MINOR": 10,
+	"MINOR": 12,
 	"PATCH": 99,
 	"BUILD": 0
 	},
-"DOWNLOAD": "https://github.com/KSP-RO/TestFlight/releases/download/2.0.0/TestFlight-2.0.0.zip"
+"DOWNLOAD": "https://github.com/KSP-RO/TestFlight/releases/download/2.10.0.0/TestFlight-2.10.0.0.zip"
 }

--- a/TestFlightAPI/TestFlightAPI/TestFlightFailure.cs
+++ b/TestFlightAPI/TestFlightAPI/TestFlightFailure.cs
@@ -116,6 +116,7 @@ namespace TestFlightAPI
                 if (!previouslyFailed)
                 {
                     core.LogCareerFailure(vessel, failureTitle);
+                    TimeWarp.SetRate(0, true);
                 }
             }
         }

--- a/TestFlightCore/TestFlightCore/TestFlightWindow.cs
+++ b/TestFlightCore/TestFlightCore/TestFlightWindow.cs
@@ -80,8 +80,6 @@ namespace TestFlightCore
             onWindowMoveComplete += MainWindow_OnWindowMoveComplete;
             CalculateWindowBounds();
             Visible = tfScenario.userSettings.showMSD;
-            // If the window is being restored as visible from saved settings, mark it sticky
-            // so HoverOutButton() doesn't immediately hide it on the first stray mouse move.
             stickyWindow = Visible;
         }
 

--- a/TestFlightCore/TestFlightCore/TestFlightWindow.cs
+++ b/TestFlightCore/TestFlightCore/TestFlightWindow.cs
@@ -80,6 +80,9 @@ namespace TestFlightCore
             onWindowMoveComplete += MainWindow_OnWindowMoveComplete;
             CalculateWindowBounds();
             Visible = tfScenario.userSettings.showMSD;
+            // If the window is being restored as visible from saved settings, mark it sticky
+            // so HoverOutButton() doesn't immediately hide it on the first stray mouse move.
+            stickyWindow = Visible;
         }
 
         public void Event_OnGameSceneLoadRequested(GameScenes scene)
@@ -244,6 +247,8 @@ namespace TestFlightCore
             GUILayout.BeginVertical();
             GUILayout.Space(10);
 
+            GUIContent closeButton = new GUIContent("X", "Close");
+
             if (masterStatus == null)
             {
                 GUILayout.BeginHorizontal();
@@ -253,6 +258,10 @@ namespace TestFlightCore
                     tfScenario.userSettings.displaySettingsWindow = !tfScenario.userSettings.displaySettingsWindow;
                     CalculateWindowBounds();
                     tfScenario.userSettings.Save();
+                }
+                if (GUILayout.Button(closeButton, GUILayout.Width(25)))
+                {
+                    CloseWindow();
                 }
                 GUILayout.EndHorizontal();
             }
@@ -265,6 +274,10 @@ namespace TestFlightCore
                     tfScenario.userSettings.displaySettingsWindow = !tfScenario.userSettings.displaySettingsWindow;
                     CalculateWindowBounds();
                     tfScenario.userSettings.Save();
+                }
+                if (GUILayout.Button(closeButton, GUILayout.Width(25)))
+                {
+                    CloseWindow();
                 }
                 GUILayout.EndHorizontal();
             }
@@ -360,12 +373,18 @@ namespace TestFlightCore
                     }
                     GUILayout.EndScrollView();
 
+                    GUILayout.BeginHorizontal();
                     if (GUILayout.Button(settingsButton, GUILayout.Width(38)))
                     {
                         tfScenario.userSettings.displaySettingsWindow = !tfScenario.userSettings.displaySettingsWindow;
                         CalculateWindowBounds();
                         tfScenario.userSettings.Save();
                     }
+                    if (GUILayout.Button(closeButton, GUILayout.Width(25)))
+                    {
+                        CloseWindow();
+                    }
+                    GUILayout.EndHorizontal();
                 }
             }
               
@@ -456,15 +475,12 @@ namespace TestFlightCore
                         {
                             if (tfScenario.userSettings.mainWindowLocked)
                             {
-                                tfScenario.userSettings.mainWindowLocked = true;
                                 CalculateWindowBounds();
                                 tfScenario.userSettings.mainWindowPosition = WindowRect;
                                 DragEnabled = false;
-                                tfScenario.userSettings.showMSD = false;
                             }
                             else
                             {
-                                tfScenario.userSettings.showMSD = Visible;
                                 DragEnabled = true;
                             }
                             tfScenario.userSettings.Save();
@@ -549,7 +565,7 @@ namespace TestFlightCore
 
         internal override void Update()
         {
-            if (Input.GetKeyDown(KeyCode.T) && Input.GetKeyDown(KeyCode.LeftAlt))
+            if (Input.GetKey(KeyCode.LeftAlt) && Input.GetKeyDown(KeyCode.T))
             {
                 if (Visible)
                     CloseWindow();

--- a/TestFlightFailure_IgnitionFail.cs
+++ b/TestFlightFailure_IgnitionFail.cs
@@ -303,13 +303,13 @@ namespace TestFlight
             ITestFlightCore core = TestFlightUtil.GetCore(this.part, Configuration);
             if (core != null)
             {
+                float multiplier = GetDynPressureModifier();
                 if (awardDuInPreLaunch || vessel.situation != Vessel.Situations.PRELAUNCH)
                 {
-                    core.ModifyFlightData(duFail, true);
+                    core.ModifyFlightData(duFail * multiplier, true);
                 }
 
                 string met = KSPUtil.PrintTimeCompact((int)Math.Floor(this.vessel.missionTime), false);
-                float multiplier = GetDynPressureModifier();
 
                 if (multiplier < 0.99)
                 {

--- a/TestFlightFailure_IgnitionFail.cs
+++ b/TestFlightFailure_IgnitionFail.cs
@@ -507,8 +507,7 @@ namespace TestFlight
         {
             if (core == null)
             {
-                Log("Core is null");
-                return;
+                core = TestFlightUtil.GetCore(part);
             }
 
             foreach (var failureModule in TestFlightUtil.GetFailureModules(this.part, core.Alias))

--- a/makeMeta.py
+++ b/makeMeta.py
@@ -42,8 +42,8 @@ avc = {
 	"KSP_VERSION_MIN" :
 	{
 		"MAJOR" : 1,
-		"MINOR" : 10,
-		"PATCH" : 1
+		"MINOR" : 12,
+		"PATCH" : 0
 	},
 	"KSP_VERSION_MAX" :
 	{


### PR DESCRIPTION
I was running into a few issues with the UX that made the mod unintuitive/difficult to use and went ahead and fixed them. This is related to issue #291, but it does not wholly address it. 

1. An 'X' Button is now present on the main window, making it much easier to close without interacting with the side toolbar. 
2. I saw Alt+T was supposed to close the window in the code, but it was done in such a way that the keyboard shortcut would never actually go through. I fixed this issue. I don't know that this shortcut is actually necessary, but I don't see it hurting anything. 
3. "Lock MSD Position" no longer affects visibility settings. 
4. The window is no longer closed after initialization by moving the mouse off of the toolbar icon for the first time, now requiring a click.