### PR TITLE
Make MSD Window Easily Closable and Fix Related UX Bugs

### DIFF
--- a/TestFlightCore/TestFlightCore/TestFlightWindow.cs
+++ b/TestFlightCore/TestFlightCore/TestFlightWindow.cs
@@ -80,6 +80,7 @@ namespace TestFlightCore
             onWindowMoveComplete += MainWindow_OnWindowMoveComplete;
             CalculateWindowBounds();
             Visible = tfScenario.userSettings.showMSD;
+            stickyWindow = Visible;
         }
 
         public void Event_OnGameSceneLoadRequested(GameScenes scene)
@@ -244,6 +245,8 @@ namespace TestFlightCore
             GUILayout.BeginVertical();
             GUILayout.Space(10);
 
+            GUIContent closeButton = new GUIContent("X", "Close");
+
             if (masterStatus == null)
             {
                 GUILayout.BeginHorizontal();
@@ -253,6 +256,10 @@ namespace TestFlightCore
                     tfScenario.userSettings.displaySettingsWindow = !tfScenario.userSettings.displaySettingsWindow;
                     CalculateWindowBounds();
                     tfScenario.userSettings.Save();
+                }
+                if (GUILayout.Button(closeButton, GUILayout.Width(25)))
+                {
+                    CloseWindow();
                 }
                 GUILayout.EndHorizontal();
             }
@@ -265,6 +272,10 @@ namespace TestFlightCore
                     tfScenario.userSettings.displaySettingsWindow = !tfScenario.userSettings.displaySettingsWindow;
                     CalculateWindowBounds();
                     tfScenario.userSettings.Save();
+                }
+                if (GUILayout.Button(closeButton, GUILayout.Width(25)))
+                {
+                    CloseWindow();
                 }
                 GUILayout.EndHorizontal();
             }
@@ -360,12 +371,18 @@ namespace TestFlightCore
                     }
                     GUILayout.EndScrollView();
 
+                    GUILayout.BeginHorizontal();
                     if (GUILayout.Button(settingsButton, GUILayout.Width(38)))
                     {
                         tfScenario.userSettings.displaySettingsWindow = !tfScenario.userSettings.displaySettingsWindow;
                         CalculateWindowBounds();
                         tfScenario.userSettings.Save();
                     }
+                    if (GUILayout.Button(closeButton, GUILayout.Width(25)))
+                    {
+                        CloseWindow();
+                    }
+                    GUILayout.EndHorizontal();
                 }
             }
               
@@ -456,15 +473,12 @@ namespace TestFlightCore
                         {
                             if (tfScenario.userSettings.mainWindowLocked)
                             {
-                                tfScenario.userSettings.mainWindowLocked = true;
                                 CalculateWindowBounds();
                                 tfScenario.userSettings.mainWindowPosition = WindowRect;
                                 DragEnabled = false;
-                                tfScenario.userSettings.showMSD = false;
                             }
                             else
                             {
-                                tfScenario.userSettings.showMSD = Visible;
                                 DragEnabled = true;
                             }
                             tfScenario.userSettings.Save();
@@ -549,7 +563,7 @@ namespace TestFlightCore
 
         internal override void Update()
         {
-            if (Input.GetKeyDown(KeyCode.T) && Input.GetKeyDown(KeyCode.LeftAlt))
+            if (Input.GetKey(KeyCode.LeftAlt) && Input.GetKeyDown(KeyCode.T))
             {
                 if (Visible)
                     CloseWindow();


### PR DESCRIPTION
I was running into a few issues with the UX that made the mod unintuitive/difficult to use and went ahead and fixed them. This is related to issue #291, but it does not wholly address it.

1. An 'X' Button is now present on the main window, making it much easier to close without interacting with the side toolbar.
2. I saw Alt+T was supposed to close the window in the code, but it was done in such a way that the keyboard shortcut would never actually go through. I fixed this issue. I don't know that this shortcut is actually necessary, but I don't see it hurting anything.
3. "Lock MSD Position" no longer affects visibility settings.
4. The window is no longer closed after initialization by moving the mouse off of the toolbar icon for the first time, now requiring a click.